### PR TITLE
API: Handle keyUp bindings

### DIFF
--- a/src/EditorInput.re
+++ b/src/EditorInput.re
@@ -65,6 +65,7 @@ module Make = (Config: {
           key.scancode == scancode && Modifiers.equals(mods, key.modifiers)
         | Keydown(Keycode(keycode, mods)) =>
           key.keycode == keycode && Modifiers.equals(mods, key.modifiers)
+        | Keyup(_) => false
         };
       }
     );

--- a/src/EditorInput.re
+++ b/src/EditorInput.re
@@ -238,9 +238,9 @@ module Make = (Config: {
     (reset(~keys, bindings), effects);
   };
 
-  let keyDown = (~context, key, bindings) => {
+  let handleKeyCore = (~context, gesture, bindings) => {
     let originalKeys = bindings.keys;
-    let keys = [Down(key), ...bindings.keys];
+    let keys = [gesture, ...bindings.keys];
 
     let candidateBindings =
       applyKeysToBindings(~context, keys |> List.rev, bindings.allBindings);
@@ -266,36 +266,15 @@ module Make = (Config: {
       | None => flush(~context, {...bindings, keys})
       };
     };
+  };
+
+  let keyDown = (~context, key, bindings) => {
+    handleKeyCore(~context, Down(key), bindings);
   };
 
   let keyUp = (~context, key, bindings) => {
-    let originalKeys = bindings.keys;
-    let keys = [Up(key), ...bindings.keys];
-
-    let candidateBindings =
-      applyKeysToBindings(~context, keys |> List.rev, bindings.allBindings);
-
-    let readyBindings = getReadyBindings(candidateBindings);
-    let readyBindingCount = List.length(readyBindings);
-    let candidateBindingCount = List.length(candidateBindings);
-
-    let potentialBindingCount = candidateBindingCount - readyBindingCount;
-
-    if (potentialBindingCount > 0) {
-      ({...bindings, keys}, []);
-    } else {
-      switch (List.nth_opt(readyBindings, 0)) {
-      | Some(binding) =>
-        switch (binding.action) {
-        | Dispatch(payload) => (reset(bindings), [Execute(payload)])
-        | Remap(remappedKeys) =>
-          let keys =
-            List.append(originalKeys, List.map(k => Down(k), remappedKeys));
-          flush(~context, {...bindings, keys});
-        }
-      | None => flush(~context, {...bindings, keys})
-      };
-    };
+    handleKeyCore(~context, Up(key), bindings);
   };
+
   let empty = {nextId: 0, allBindings: [], keys: []};
 };

--- a/src/EditorInput.re
+++ b/src/EditorInput.re
@@ -51,21 +51,29 @@ module Make = (Config: {
     enabled: context => bool,
   };
 
+  type gesture =
+    | Down(key)
+    | Up(key);
+
   type t = {
     nextId: int,
     allBindings: list(binding),
-    keys: list(key),
+    keys: list(gesture),
   };
 
-  let keyMatches = (keyMatcher, key) => {
+  let keyMatches = (keyMatcher, key: gesture) => {
     Matcher.(
       {
-        switch (keyMatcher) {
-        | Keydown(Scancode(scancode, mods)) =>
+        switch (keyMatcher, key) {
+        | (Keydown(Scancode(scancode, mods)), Down(key)) =>
           key.scancode == scancode && Modifiers.equals(mods, key.modifiers)
-        | Keydown(Keycode(keycode, mods)) =>
+        | (Keydown(Keycode(keycode, mods)), Down(key)) =>
           key.keycode == keycode && Modifiers.equals(mods, key.modifiers)
-        | Keyup(_) => false
+        | (Keyup(Scancode(scancode, mods)), Up(key)) =>
+          key.scancode == scancode && Modifiers.equals(mods, key.modifiers)
+        | (Keyup(Keycode(keycode, mods)), Up(key)) =>
+          key.keycode == keycode && Modifiers.equals(mods, key.modifiers)
+        | _ => false
         };
       }
     );
@@ -88,11 +96,47 @@ module Make = (Config: {
   };
 
   let applyKeysToBindings = (~context, keys, bindings) => {
-    List.fold_left(
-      (acc, curr) => {applyKeyToBindings(~context, curr, acc)},
-      bindings,
-      keys,
-    );
+    let bindingsWithKeyUp =
+      keys
+      |> List.fold_left(
+           (acc, curr) => {applyKeyToBindings(~context, curr, acc)},
+           bindings,
+         );
+
+    let consumedBindings =
+      bindingsWithKeyUp
+      |> List.fold_left(
+           (acc, curr) => {
+             Hashtbl.add(acc, curr.id, true);
+             acc;
+           },
+           Hashtbl.create(16),
+         );
+
+    let unusedBindings =
+      bindings
+      |> List.filter(binding =>
+           Stdlib.Option.is_none(
+             Hashtbl.find_opt(consumedBindings, binding.id),
+           )
+         );
+
+    let onlyDownKeys =
+      keys
+      |> List.filter_map(
+           fun
+           | Down(key) => Some(Down(key))
+           | Up(key) => None,
+         );
+
+    let bindingsWithJustKeyDown =
+      onlyDownKeys
+      |> List.fold_left(
+           (acc, curr) => {applyKeyToBindings(~context, curr, acc)},
+           unusedBindings,
+         );
+
+    bindingsWithKeyUp @ bindingsWithJustKeyDown;
   };
 
   let addBinding = (sequence, enabled, payload, bindings) => {
@@ -150,12 +194,13 @@ module Make = (Config: {
               [Execute(payload), ...effects],
             )
           | Remap(keys) =>
+            let newKeys = keys |> List.map(k => Down(k)) |> List.rev;
             loop(
               flush,
-              List.append(List.rev(keys), revKeys),
+              List.append(newKeys, revKeys),
               remainingKeys,
               effects,
-            )
+            );
           };
         } else {
           (List.append(revKeys, remainingKeys), effects);
@@ -172,9 +217,12 @@ module Make = (Config: {
         | [] =>
           // No keys left, we're done here
           (remainingKeys, effects)
-        | [latestKey] =>
+        | [Down(latestKey)] =>
           // At the last key... if we got here, we couldn't find any match for this key
           ([], [Unhandled(latestKey), ...effects])
+        | [Up(latestKey)] =>
+          // At the last key... if we got here, we couldn't find any match for this key
+          ([], effects)
         | [latestKey, ...otherKeys] =>
           // Try a subset of keys
           loop(flush, otherKeys, [latestKey, ...remainingKeys], effects)
@@ -192,7 +240,7 @@ module Make = (Config: {
 
   let keyDown = (~context, key, bindings) => {
     let originalKeys = bindings.keys;
-    let keys = [key, ...bindings.keys];
+    let keys = [Down(key), ...bindings.keys];
 
     let candidateBindings =
       applyKeysToBindings(~context, keys |> List.rev, bindings.allBindings);
@@ -211,7 +259,8 @@ module Make = (Config: {
         switch (binding.action) {
         | Dispatch(payload) => (reset(bindings), [Execute(payload)])
         | Remap(remappedKeys) =>
-          let keys = List.append(originalKeys, remappedKeys);
+          let keys =
+            List.append(originalKeys, List.map(k => Down(k), remappedKeys));
           flush(~context, {...bindings, keys});
         }
       | None => flush(~context, {...bindings, keys})
@@ -219,7 +268,34 @@ module Make = (Config: {
     };
   };
 
-  let keyUp = (~context as _, _key, bindings) => (bindings, []);
+  let keyUp = (~context, key, bindings) => {
+    let originalKeys = bindings.keys;
+    let keys = [Up(key), ...bindings.keys];
 
+    let candidateBindings =
+      applyKeysToBindings(~context, keys |> List.rev, bindings.allBindings);
+
+    let readyBindings = getReadyBindings(candidateBindings);
+    let readyBindingCount = List.length(readyBindings);
+    let candidateBindingCount = List.length(candidateBindings);
+
+    let potentialBindingCount = candidateBindingCount - readyBindingCount;
+
+    if (potentialBindingCount > 0) {
+      ({...bindings, keys}, []);
+    } else {
+      switch (List.nth_opt(readyBindings, 0)) {
+      | Some(binding) =>
+        switch (binding.action) {
+        | Dispatch(payload) => (reset(bindings), [Execute(payload)])
+        | Remap(remappedKeys) =>
+          let keys =
+            List.append(originalKeys, List.map(k => Down(k), remappedKeys));
+          flush(~context, {...bindings, keys});
+        }
+      | None => flush(~context, {...bindings, keys})
+      };
+    };
+  };
   let empty = {nextId: 0, allBindings: [], keys: []};
 };

--- a/src/EditorInput.re
+++ b/src/EditorInput.re
@@ -61,9 +61,9 @@ module Make = (Config: {
     Matcher.(
       {
         switch (keyMatcher) {
-        | Scancode(scancode, mods) =>
+        | Keydown(Scancode(scancode, mods)) =>
           key.scancode == scancode && Modifiers.equals(mods, key.modifiers)
-        | Keycode(keycode, mods) =>
+        | Keydown(Keycode(keycode, mods)) =>
           key.keycode == keycode && Modifiers.equals(mods, key.modifiers)
         };
       }

--- a/src/EditorInput.rei
+++ b/src/EditorInput.rei
@@ -19,7 +19,8 @@ module Matcher: {
     | Keycode(int, Modifiers.t);
 
   type t =
-  | Keydown(keyMatcher);
+    | Keydown(keyMatcher)
+    | Keyup(keyMatcher);
 
   type sequence = list(t);
 

--- a/src/EditorInput.rei
+++ b/src/EditorInput.rei
@@ -14,9 +14,12 @@ module Modifiers: {
 };
 
 module Matcher: {
-  type t =
+  type keyMatcher =
     | Scancode(int, Modifiers.t)
     | Keycode(int, Modifiers.t);
+
+  type t =
+  | Keydown(keyMatcher);
 
   type sequence = list(t);
 

--- a/src/Matcher.re
+++ b/src/Matcher.re
@@ -1,6 +1,9 @@
-type t =
+type keyMatcher =
   | Scancode(int, Modifiers.t)
   | Keycode(int, Modifiers.t);
+
+type t = 
+| Keydown(keyMatcher);
 
 type sequence = list(t);
 
@@ -34,7 +37,7 @@ let parse = (~getKeycode, ~getScancode, str) => {
       let (key, mods) = parseResult;
       switch (getKeycode(key)) {
       | None => Error("Unrecognized key: " ++ key)
-      | Some(code) => Ok(Keycode(code, internalModsToMods(mods)))
+    | Some(code) => Ok(Keydown(Keycode(code, internalModsToMods(mods))))
       };
     };
 

--- a/src/Matcher.re
+++ b/src/Matcher.re
@@ -2,8 +2,9 @@ type keyMatcher =
   | Scancode(int, Modifiers.t)
   | Keycode(int, Modifiers.t);
 
-type t = 
-| Keydown(keyMatcher);
+type t =
+  | Keydown(keyMatcher)
+  | Keyup(keyMatcher);
 
 type sequence = list(t);
 
@@ -34,10 +35,16 @@ let parse = (~getKeycode, ~getScancode, str) => {
 
   let finish = r => {
     let f = parseResult => {
-      let (key, mods) = parseResult;
+      let (activation, key, mods) = parseResult;
       switch (getKeycode(key)) {
       | None => Error("Unrecognized key: " ++ key)
-    | Some(code) => Ok(Keydown(Keycode(code, internalModsToMods(mods))))
+      | Some(code) =>
+        switch (activation) {
+        | Matcher_internal.Keydown =>
+          Ok(Keydown(Keycode(code, internalModsToMods(mods))))
+        | Matcher_internal.Keyup =>
+          Ok(Keyup(Keycode(code, internalModsToMods(mods))))
+        }
       };
     };
 

--- a/src/Matcher_internal.re
+++ b/src/Matcher_internal.re
@@ -4,4 +4,8 @@ type modifier =
   | Alt
   | Meta;
 
-type t = (string, list(modifier));
+type activation =
+  | Keyup
+  | Keydown;
+
+type t = (activation, string, list(modifier));

--- a/src/Matcher_lexer.mll
+++ b/src/Matcher_lexer.mll
@@ -36,6 +36,7 @@ rule token = parse
  }
 (* Single keys *)
 | white { token lexbuf }
+| '!' { EXCLAMATION }
 | ['a' - 'z' 'A' - 'Z' '0'-'9']  as i
  { BINDING (String.make 1 (Char.lowercase_ascii i)) }
 | '<' { LT }

--- a/src/Matcher_parser.mly
+++ b/src/Matcher_parser.mly
@@ -1,6 +1,7 @@
 %token <Matcher_internal.modifier> MODIFIER
 %token <string> BINDING
 %token LT GT
+%token EXCLAMATION
 %token EOF
 
 %start <Matcher_internal.t list> main
@@ -11,9 +12,14 @@ main:
 | phrase = list(expr) EOF { phrase }
 
 expr:
-| LT e = binding GT { e }
-| s = binding { s }
+| EXCLAMATION; LT e = keyup_binding GT { e }
+| EXCLAMATION; s = keyup_binding { s }
+| LT e = keydown_binding GT { e }
+| s = keydown_binding { s }
 
-binding:
-| modifiers = list(MODIFIER); binding = BINDING { (binding, modifiers) };
+keyup_binding:
+| modifiers = list(MODIFIER); binding = BINDING { (Matcher_internal.Keyup, binding, modifiers) }
+
+keydown_binding:
+| modifiers = list(MODIFIER); binding = BINDING { (Matcher_internal.Keydown, binding, modifiers) }
 

--- a/test/InputTest.re
+++ b/test/InputTest.re
@@ -34,8 +34,10 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [Keydown(Keycode(1, Modifiers.none)),
-             Keydown(Keycode(2, Modifiers.none))],
+             [
+               Keydown(Keycode(1, Modifiers.none)),
+               Keydown(Keycode(2, Modifiers.none)),
+             ],
              _ => true,
              "payloadAB",
            );
@@ -63,8 +65,10 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [Keydown(Keycode(1, Modifiers.none)),
-             Keydown(Keycode(2, Modifiers.none))],
+             [
+               Keydown(Keycode(1, Modifiers.none)),
+               Keydown(Keycode(2, Modifiers.none)),
+             ],
              _ => true,
              "payload1",
            );
@@ -83,8 +87,10 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [Keydown(Keycode(1, Modifiers.none)),
-             Keydown(Keycode(1, Modifiers.none))],
+             [
+               Keydown(Keycode(1, Modifiers.none)),
+               Keydown(Keycode(1, Modifiers.none)),
+             ],
              _ => true,
              "payloadAA",
            );
@@ -103,8 +109,10 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [Keydown(Keycode(1, Modifiers.none)),
-             Keydown(Keycode(3, Modifiers.none))],
+             [
+               Keydown(Keycode(1, Modifiers.none)),
+               Keydown(Keycode(3, Modifiers.none)),
+             ],
              _ => true,
              "payloadAC",
            );
@@ -136,8 +144,10 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [Keydown(Keycode(1, Modifiers.none)),
-             Keydown(Keycode(3, Modifiers.none))],
+             [
+               Keydown(Keycode(1, Modifiers.none)),
+               Keydown(Keycode(3, Modifiers.none)),
+             ],
              _ => true,
              "payloadAC",
            );
@@ -185,8 +195,10 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [Keydown(Keycode(1, Modifiers.none)),
-             Keydown(Keycode(3, Modifiers.none))],
+             [
+               Keydown(Keycode(1, Modifiers.none)),
+               Keydown(Keycode(3, Modifiers.none)),
+             ],
              identity,
              "payloadAC",
            );
@@ -241,8 +253,10 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addMapping(
-             [Keydown(Keycode(1, Modifiers.none)),
-             Keydown(Keycode(2, Modifiers.none))],
+             [
+               Keydown(Keycode(1, Modifiers.none)),
+               Keydown(Keycode(2, Modifiers.none)),
+             ],
              _ => true,
              [cKeyNoModifiers],
            );

--- a/test/InputTest.re
+++ b/test/InputTest.re
@@ -34,7 +34,8 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [Keycode(1, Modifiers.none), Keycode(2, Modifiers.none)],
+             [Keydown(Keycode(1, Modifiers.none)),
+             Keydown(Keycode(2, Modifiers.none))],
              _ => true,
              "payloadAB",
            );
@@ -42,7 +43,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         bindings
         |> Input.addBinding(
-             [Keycode(1, Modifiers.none)],
+             [Keydown(Keycode(1, Modifiers.none))],
              _ => true,
              "payloadA",
            );
@@ -62,7 +63,8 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [Keycode(1, Modifiers.none), Keycode(2, Modifiers.none)],
+             [Keydown(Keycode(1, Modifiers.none)),
+             Keydown(Keycode(2, Modifiers.none))],
              _ => true,
              "payload1",
            );
@@ -81,7 +83,8 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [Keycode(1, Modifiers.none), Keycode(1, Modifiers.none)],
+             [Keydown(Keycode(1, Modifiers.none)),
+             Keydown(Keycode(1, Modifiers.none))],
              _ => true,
              "payloadAA",
            );
@@ -100,7 +103,8 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [Keycode(1, Modifiers.none), Keycode(3, Modifiers.none)],
+             [Keydown(Keycode(1, Modifiers.none)),
+             Keydown(Keycode(3, Modifiers.none))],
              _ => true,
              "payloadAC",
            );
@@ -108,7 +112,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         bindings
         |> Input.addBinding(
-             [Keycode(1, Modifiers.none)],
+             [Keydown(Keycode(1, Modifiers.none))],
              _ => true,
              "payloadA",
            );
@@ -132,7 +136,8 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [Keycode(1, Modifiers.none), Keycode(3, Modifiers.none)],
+             [Keydown(Keycode(1, Modifiers.none)),
+             Keydown(Keycode(3, Modifiers.none))],
              _ => true,
              "payloadAC",
            );
@@ -140,7 +145,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         bindings
         |> Input.addBinding(
-             [Keycode(1, Modifiers.none)],
+             [Keydown(Keycode(1, Modifiers.none))],
              _ => true,
              "payloadA",
            );
@@ -165,7 +170,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [Keycode(1, Modifiers.none)],
+             [Keydown(Keycode(1, Modifiers.none))],
              identity,
              "payload1",
            );
@@ -180,7 +185,8 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [Keycode(1, Modifiers.none), Keycode(3, Modifiers.none)],
+             [Keydown(Keycode(1, Modifiers.none)),
+             Keydown(Keycode(3, Modifiers.none))],
              identity,
              "payloadAC",
            );
@@ -196,7 +202,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [Keycode(1, Modifiers.none)],
+             [Keydown(Keycode(1, Modifiers.none))],
              _ => true,
              "payload1",
            );
@@ -220,7 +226,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addMapping(
-             [Keycode(1, Modifiers.none)],
+             [Keydown(Keycode(1, Modifiers.none))],
              _ => true,
              [bKeyNoModifiers],
            );
@@ -235,7 +241,8 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addMapping(
-             [Keycode(1, Modifiers.none), Keycode(2, Modifiers.none)],
+             [Keydown(Keycode(1, Modifiers.none)),
+             Keydown(Keycode(2, Modifiers.none))],
              _ => true,
              [cKeyNoModifiers],
            );
@@ -252,7 +259,7 @@ describe("EditorInput", ({describe, _}) => {
         let (bindings, _id) =
           Input.empty
           |> Input.addMapping(
-               [Keycode(1, Modifiers.none)],
+               [Keydown(Keycode(1, Modifiers.none)],
                _ => true,
                [bKeyNoModifiers, cKeyNoModifiers],
              );
@@ -267,14 +274,14 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addMapping(
-             [Keycode(1, Modifiers.none)],
+             [Keydown(Keycode(1, Modifiers.none))],
              _ => true,
              [bKeyNoModifiers],
            );
       let (bindings, _id) =
         bindings
         |> Input.addBinding(
-             [Keycode(2, Modifiers.none)],
+             [Keydown(Keycode(2, Modifiers.none))],
              _ => true,
              "payload2",
            );

--- a/test/InputTest.re
+++ b/test/InputTest.re
@@ -105,6 +105,55 @@ describe("EditorInput", ({describe, _}) => {
 
       expect.equal(effects, [Execute("payloadAA")]);
     });
+    test("key up doesn't stop sequence", ({expect}) => {
+      let (bindings, _id) =
+        Input.empty
+        |> Input.addBinding(
+             [
+               Keydown(Keycode(1, Modifiers.none)),
+               Keydown(Keycode(2, Modifiers.none)),
+             ],
+             _ => true,
+             "payloadAB",
+           );
+
+      let (bindings, effects) =
+        Input.keyDown(~context=true, aKeyNoModifiers, bindings);
+
+      expect.equal(effects, []);
+
+      let (bindings, effects) =
+        Input.keyUp(~context=true, aKeyNoModifiers, bindings);
+
+      expect.equal(effects, []);
+
+      let (bindings, effects) =
+        Input.keyDown(~context=true, bKeyNoModifiers, bindings);
+
+      expect.equal(effects, [Execute("payloadAB")]);
+    });
+    test("sequence with keyups", ({expect}) => {
+      let (bindings, _id) =
+        Input.empty
+        |> Input.addBinding(
+             [
+               Keydown(Keycode(1, Modifiers.none)),
+               Keyup(Keycode(1, Modifiers.none)),
+             ],
+             _ => true,
+             "payloadA!A",
+           );
+
+      let (bindings, effects) =
+        Input.keyDown(~context=true, aKeyNoModifiers, bindings);
+
+      expect.equal(effects, []);
+
+      let (bindings, effects) =
+        Input.keyUp(~context=true, aKeyNoModifiers, bindings);
+
+      expect.equal(effects, [Execute("payloadA!A")]);
+    });
     test("partial match with another match", ({expect}) => {
       let (bindings, _id) =
         Input.empty

--- a/test/MatcherTest.re
+++ b/test/MatcherTest.re
@@ -21,59 +21,59 @@ describe("Matcher", ({describe, _}) => {
   describe("parser", ({test, _}) => {
     test("simple parsing", ({expect}) => {
       let result = defaultParse("a");
-      expect.equal(result, Ok([Keycode(1, Modifiers.none)]));
+      expect.equal(result, Ok([Keydown(Keycode(1, Modifiers.none))]));
 
       let result = defaultParse("b");
-      expect.equal(result, Ok([Keycode(2, Modifiers.none)]));
+      expect.equal(result, Ok([Keydown(Keycode(2, Modifiers.none))]));
 
       let result = defaultParse("c");
       expect.equal(Result.is_error(result), true);
     });
     test("vim bindings", ({expect}) => {
       let result = defaultParse("<a>");
-      expect.equal(result, Ok([Keycode(1, Modifiers.none)]));
+      expect.equal(result, Ok([Keydown(Keycode(1, Modifiers.none))]));
 
       let result = defaultParse("<c-a>");
-      expect.equal(result, Ok([Keycode(1, modifiersControl)]));
+      expect.equal(result, Ok([Keydown(Keycode(1, modifiersControl))]));
 
       let result = defaultParse("<S-a>");
-      expect.equal(result, Ok([Keycode(1, modifiersShift)]));
+      expect.equal(result, Ok([Keydown(Keycode(1, modifiersShift))]));
     });
     test("vscode bindings", ({expect}) => {
       let result = defaultParse("Ctrl+a");
-      expect.equal(result, Ok([Keycode(1, modifiersControl)]));
+      expect.equal(result, Ok([Keydown(Keycode(1, modifiersControl))]));
 
       let result = defaultParse("ctrl+a");
-      expect.equal(result, Ok([Keycode(1, modifiersControl)]));
+      expect.equal(result, Ok([Keydown(Keycode(1, modifiersControl))]));
     });
     test("binding list", ({expect}) => {
       let result = defaultParse("ab");
       expect.equal(
         result,
-        Ok([Keycode(1, Modifiers.none), Keycode(2, Modifiers.none)]),
+        Ok([Keydown(Keycode(1, Modifiers.none)), Keydown(Keycode(2, Modifiers.none))]),
       );
 
       let result = defaultParse("a b");
       expect.equal(
         result,
-        Ok([Keycode(1, Modifiers.none), Keycode(2, Modifiers.none)]),
+        Ok([Keydown(Keycode(1, Modifiers.none)), Keydown(Keycode(2, Modifiers.none))]),
       );
 
       let result = defaultParse("<a>b");
       expect.equal(
         result,
-        Ok([Keycode(1, Modifiers.none), Keycode(2, Modifiers.none)]),
+        Ok([Keydown(Keycode(1, Modifiers.none)), Keydown(Keycode(2, Modifiers.none))]),
       );
       let result = defaultParse("<a><b>");
       expect.equal(
         result,
-        Ok([Keycode(1, Modifiers.none), Keycode(2, Modifiers.none)]),
+        Ok([Keydown(Keycode(1, Modifiers.none)), Keydown(Keycode(2, Modifiers.none))]),
       );
 
       let result = defaultParse("<c-a> Ctrl+b");
       expect.equal(
         result,
-        Ok([Keycode(1, modifiersControl), Keycode(2, modifiersControl)]),
+        Ok([Keydown(Keycode(1, modifiersControl)), Keydown(Keycode(2, modifiersControl))]),
       );
     });
   })

--- a/test/MatcherTest.re
+++ b/test/MatcherTest.re
@@ -50,30 +50,76 @@ describe("Matcher", ({describe, _}) => {
       let result = defaultParse("ab");
       expect.equal(
         result,
-        Ok([Keydown(Keycode(1, Modifiers.none)), Keydown(Keycode(2, Modifiers.none))]),
+        Ok([
+          Keydown(Keycode(1, Modifiers.none)),
+          Keydown(Keycode(2, Modifiers.none)),
+        ]),
       );
 
       let result = defaultParse("a b");
       expect.equal(
         result,
-        Ok([Keydown(Keycode(1, Modifiers.none)), Keydown(Keycode(2, Modifiers.none))]),
+        Ok([
+          Keydown(Keycode(1, Modifiers.none)),
+          Keydown(Keycode(2, Modifiers.none)),
+        ]),
       );
 
       let result = defaultParse("<a>b");
       expect.equal(
         result,
-        Ok([Keydown(Keycode(1, Modifiers.none)), Keydown(Keycode(2, Modifiers.none))]),
+        Ok([
+          Keydown(Keycode(1, Modifiers.none)),
+          Keydown(Keycode(2, Modifiers.none)),
+        ]),
       );
       let result = defaultParse("<a><b>");
       expect.equal(
         result,
-        Ok([Keydown(Keycode(1, Modifiers.none)), Keydown(Keycode(2, Modifiers.none))]),
+        Ok([
+          Keydown(Keycode(1, Modifiers.none)),
+          Keydown(Keycode(2, Modifiers.none)),
+        ]),
       );
 
       let result = defaultParse("<c-a> Ctrl+b");
       expect.equal(
         result,
-        Ok([Keydown(Keycode(1, modifiersControl)), Keydown(Keycode(2, modifiersControl))]),
+        Ok([
+          Keydown(Keycode(1, modifiersControl)),
+          Keydown(Keycode(2, modifiersControl)),
+        ]),
+      );
+    });
+    test("keyup", ({expect}) => {
+      let result = defaultParse("!a");
+      expect.equal(result, Ok([Keyup(Keycode(1, Modifiers.none))]));
+
+      let result = defaultParse("a!a");
+      expect.equal(
+        result,
+        Ok([
+          Keydown(Keycode(1, Modifiers.none)),
+          Keyup(Keycode(1, Modifiers.none)),
+        ]),
+      );
+
+      let result = defaultParse("a !Ctrl+a");
+      expect.equal(
+        result,
+        Ok([
+          Keydown(Keycode(1, Modifiers.none)),
+          Keyup(Keycode(1, modifiersControl)),
+        ]),
+      );
+
+      let result = defaultParse("a !<C-A>");
+      expect.equal(
+        result,
+        Ok([
+          Keydown(Keycode(1, Modifiers.none)),
+          Keyup(Keycode(1, modifiersControl)),
+        ]),
       );
     });
   })


### PR DESCRIPTION
This adds support for key up bindings, where the `!` operator matches a key up.

For example: `a b !a` would require `a` and `b` both to be pressed, and then `a` to be released to trigger.