### PR TITLE
Bugfix: Recursive mappings hang

### DIFF
--- a/src/EditorInput.re
+++ b/src/EditorInput.re
@@ -182,7 +182,7 @@ module Make = (Config: {
   let flush = (~context, bindings) => {
     let allKeys = bindings.keys;
 
-    let rec loop = (flush, revKeys, remainingKeys, effects, iterationCount) => {
+    let rec loop = (~flush, revKeys, remainingKeys, effects, iterationCount) => {
       let candidateBindings =
         bindings.allBindings
         |> applyKeysToBindings(~context, revKeys |> List.rev);
@@ -211,7 +211,7 @@ module Make = (Config: {
             )
           | Remap(keys) =>
             let newKeys = keys |> List.map(k => Down(k)) |> List.rev;
-            loop(flush, newKeys, remainingKeys, effects, iterationCount + 1);
+            loop(~flush, newKeys, remainingKeys, effects, iterationCount + 1);
           };
         } else {
           (List.append(revKeys, remainingKeys), effects);
@@ -237,7 +237,7 @@ module Make = (Config: {
         | [latestKey, ...otherKeys] =>
           // Try a subset of keys
           loop(
-            flush,
+            ~flush,
             otherKeys,
             [latestKey, ...remainingKeys],
             effects,
@@ -247,10 +247,10 @@ module Make = (Config: {
       };
     };
 
-    let (remainingKeys, effects) = loop(true, allKeys, [], [], 0);
+    let (remainingKeys, effects) = loop(~flush=true, allKeys, [], [], 0);
 
     let (remainingKeys, effects) =
-      loop(false, remainingKeys, [], effects, 0);
+      loop(~flush=false, remainingKeys, [], effects, 0);
 
     let keys = remainingKeys;
     (reset(~keys, bindings), effects);

--- a/src/EditorInput.re
+++ b/src/EditorInput.re
@@ -169,16 +169,32 @@ module Make = (Config: {
     bindings |> List.filter(filter);
   };
 
+  let isRemap = ({action, _}) =>
+    switch (action) {
+    | Dispatch(_) => false
+    | Remap(_) => true
+    };
+
+  module Constants = {
+    let maxRecursiveDepth = 10;
+  };
+
   let flush = (~context, bindings) => {
     let allKeys = bindings.keys;
 
-    let rec loop = (flush, revKeys, remainingKeys, effects) => {
+    let rec loop = (flush, revKeys, remainingKeys, effects, iterationCount) => {
       let candidateBindings =
-        applyKeysToBindings(
-          ~context,
-          revKeys |> List.rev,
-          bindings.allBindings,
-        );
+        bindings.allBindings
+        |> applyKeysToBindings(~context, revKeys |> List.rev);
+
+      // If we've hit the recursion limit for remaps... filter out remaps
+      let candidateBindings =
+        if (iterationCount > Constants.maxRecursiveDepth) {
+          candidateBindings |> List.filter(binding => !isRemap(binding));
+        } else {
+          candidateBindings;
+        };
+
       let readyBindings = getReadyBindings(candidateBindings);
       let readyBindingCount = List.length(readyBindings);
       let candidateBindingCount = List.length(candidateBindings);
@@ -195,12 +211,7 @@ module Make = (Config: {
             )
           | Remap(keys) =>
             let newKeys = keys |> List.map(k => Down(k)) |> List.rev;
-            loop(
-              flush,
-              List.append(newKeys, revKeys),
-              remainingKeys,
-              effects,
-            );
+            loop(flush, newKeys, remainingKeys, effects, iterationCount + 1);
           };
         } else {
           (List.append(revKeys, remainingKeys), effects);
@@ -225,14 +236,21 @@ module Make = (Config: {
           ([], effects)
         | [latestKey, ...otherKeys] =>
           // Try a subset of keys
-          loop(flush, otherKeys, [latestKey, ...remainingKeys], effects)
+          loop(
+            flush,
+            otherKeys,
+            [latestKey, ...remainingKeys],
+            effects,
+            iterationCount,
+          )
         }
       };
     };
 
-    let (remainingKeys, effects) = loop(true, allKeys, [], []);
+    let (remainingKeys, effects) = loop(true, allKeys, [], [], 0);
 
-    let (remainingKeys, effects) = loop(false, remainingKeys, [], effects);
+    let (remainingKeys, effects) =
+      loop(false, remainingKeys, [], effects, 0);
 
     let keys = remainingKeys;
     (reset(~keys, bindings), effects);

--- a/test/InputTest.re
+++ b/test/InputTest.re
@@ -298,6 +298,44 @@ describe("EditorInput", ({describe, _}) => {
       expect.equal(effects, [Unhandled(bKeyNoModifiers)]);
     });
 
+    test("2-step recursive mapping", ({expect}) => {
+      let (bindings, _id) =
+        Input.empty
+        |> Input.addMapping(
+             [Keydown(Keycode(1, Modifiers.none))],
+             _ => true,
+             [bKeyNoModifiers],
+           );
+
+      let (bindings, _id) =
+        bindings
+        |> Input.addMapping(
+             [Keydown(Keycode(2, Modifiers.none))],
+             _ => true,
+             [cKeyNoModifiers],
+           );
+
+      let (_bindings, effects) =
+        Input.keyDown(~context=true, aKeyNoModifiers, bindings);
+
+      expect.equal(effects, [Unhandled(cKeyNoModifiers)]);
+    });
+
+    test("recursive mapping doesn't hang", ({expect}) => {
+      let (bindings, _id) =
+        Input.empty
+        |> Input.addMapping(
+             [Keydown(Keycode(1, Modifiers.none))],
+             _ => true,
+             [aKeyNoModifiers],
+           );
+
+      let (_bindings, effects) =
+        Input.keyDown(~context=true, aKeyNoModifiers, bindings);
+
+      expect.equal(effects, [Unhandled(aKeyNoModifiers)]);
+    });
+
     test("unhandled, sequence remap", ({expect}) => {
       let (bindings, _id) =
         Input.empty


### PR DESCRIPTION
__Defect:__ If there is a remap binding of the form `a -> a`, it will hang as it continually recursively remaps.

__Fix:__ Limit the maximum recursion depth for recursive bindings