### PR TITLE
API: Implement textInput + keyUp APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "esy": {
     "build": ["refmterr dune build -p editor-input"],
-    "buildsInSource": "_build",
     "install": [
         "esy-installer editor-input.install"
     ]

--- a/src/EditorInput.re
+++ b/src/EditorInput.re
@@ -22,6 +22,7 @@ module type Input = {
 
   type effects =
     | Execute(payload)
+    | Text(string)
     | Unhandled(key);
 
   let keyDown: (~context: context, ~key: key, t) => (t, list(effects));
@@ -55,6 +56,7 @@ module Make = (Config: {
 
   type effects =
     | Execute(payload)
+    | Text(string)
     | Unhandled(key);
 
   type action =

--- a/src/EditorInput.rei
+++ b/src/EditorInput.rei
@@ -46,13 +46,11 @@ module type Input = {
 
   type uniqueId;
 
-  let addBinding: (Matcher.sequence, context => bool, payload, t) => 
-    (t, uniqueId);
+  let addBinding:
+    (Matcher.sequence, context => bool, payload, t) => (t, uniqueId);
 
   let addMapping:
-    (Matcher.sequence, context => bool, list(key), t) => (
-    t, uniqueId
-    );
+    (Matcher.sequence, context => bool, list(key), t) => (t, uniqueId);
 
   type effects =
     | Execute(payload)

--- a/src/EditorInput.rei
+++ b/src/EditorInput.rei
@@ -2,11 +2,21 @@ module Modifiers: {
   type t = {
     control: bool,
     alt: bool,
+    altGr: bool,
     shift: bool,
     meta: bool,
   };
 
-  let create: (~control: bool, ~alt: bool, ~shift: bool, ~meta: bool) => t;
+  let create:
+    (
+      ~control: bool=?,
+      ~alt: bool=?,
+      ~altGr: bool=?,
+      ~shift: bool=?,
+      ~meta: bool=?,
+      unit
+    ) =>
+    t;
 
   let none: t;
 

--- a/src/EditorInput.rei
+++ b/src/EditorInput.rei
@@ -56,17 +56,32 @@ module type Input = {
 
   type t;
 
-  let addBinding: (Matcher.sequence, context => bool, payload, t) => (t, int);
+  type uniqueId;
+
+  let addBinding: (Matcher.sequence, context => bool, payload, t) => 
+    (t, uniqueId);
+
   let addMapping:
-    (Matcher.sequence, context => bool, list(key), t) => (t, int);
+    (Matcher.sequence, context => bool, list(key), t) => (
+    t, uniqueId
+    );
 
   type effects =
     | Execute(payload)
     | Unhandled(key);
 
-  let keyDown: (~context: context, key, t) => (t, list(effects));
-  let keyUp: (~context: context, key, t) => (t, list(effects));
+  let keyDown: (~context: context, ~key: key, t) => (t, list(effects));
+  let text: (~text: string, t) => (t, list(effects));
+  let keyUp: (~context: context, ~key: key, t) => (t, list(effects));
   let flush: (~context: context, t) => (t, list(effects));
+
+  /**
+  [isPending(bindings)] returns true if there is a potential
+  keybinding pending, false otherwise
+  */
+  let isPending: t => bool;
+
+  let concat: (t, t) => t;
 
   let empty: t;
 };

--- a/src/EditorInput.rei
+++ b/src/EditorInput.rei
@@ -47,7 +47,6 @@ type key = {
   scancode: int,
   keycode: int,
   modifiers: Modifiers.t,
-  text: string,
 };
 
 module type Input = {

--- a/src/EditorInput.rei
+++ b/src/EditorInput.rei
@@ -68,6 +68,7 @@ module type Input = {
 
   type effects =
     | Execute(payload)
+    | Text(string)
     | Unhandled(key);
 
   let keyDown: (~context: context, ~key: key, t) => (t, list(effects));

--- a/src/Matcher.re
+++ b/src/Matcher.re
@@ -71,5 +71,7 @@ let parse = (~getKeycode, ~getScancode, str) => {
     };
   };
 
-  str |> Lexing.from_string |> parse |> flatMap(finish);
+  str
+  |> String.lowercase_ascii
+  |> Lexing.from_string |> parse |> flatMap(finish);
 };

--- a/src/Matcher.re
+++ b/src/Matcher.re
@@ -73,5 +73,7 @@ let parse = (~getKeycode, ~getScancode, str) => {
 
   str
   |> String.lowercase_ascii
-  |> Lexing.from_string |> parse |> flatMap(finish);
+  |> Lexing.from_string
+  |> parse
+  |> flatMap(finish);
 };

--- a/src/Matcher_lexer.mll
+++ b/src/Matcher_lexer.mll
@@ -26,20 +26,42 @@ let white = [' ' '\t']+
 let alpha = ['a' - 'z' 'A' - 'Z']
 let modifier = alpha+ ['-' '+']
 
+let binding = ['a'-'z' 'A'-'Z' '0'-'9' '`' '-' '=' '[' ']' '\\' ';' '\'']
+
 rule token = parse
 | modifier as m
  { 
  	let m = String.lowercase_ascii m in
 	try Hashtbl.find modifierTable m
 	with Not_found ->
-		BINDING(m)
+		BINDING (m)
  }
 (* Single keys *)
+| "esc" { BINDING ("Escape") }
+| "escape" { BINDING ("Escape") }
+| "up" { BINDING ("Up") }
+| "down" { BINDING ("Down") }
+| "left" { BINDING ("Left") }
+| "right" { BINDING ("Right") }
+| "tab" { BINDING ("Tab") }
+| "pageup" { BINDING ("PageUp") }
+| "pagedown" { BINDING ("PageDown") }
+| "cr" { BINDING ("Return") }
+| "enter" { BINDING ("Return") }
+| "space" { BINDING ("Space") }
+| "del" { BINDING ("Delete") }
+| "delete" { BINDING ("Delete") }
+| "pause" { BINDING ("Pause") }
+| "pausebreak" { BINDING ("Pause") }
 | white { token lexbuf }
 | '!' { EXCLAMATION }
-| ['a' - 'z' 'A' - 'Z' '0'-'9']  as i
+| binding as i
  { BINDING (String.make 1 (Char.lowercase_ascii i)) }
 | '<' { LT }
 | '>' { GT }
 | eof { EOF }
 | _ { raise Error }
+
+and single_tokens = parse
+| ['a' - 'z' 'A' - 'Z' '0'-'9']  as i
+ { BINDING (String.make 1 (Char.lowercase_ascii i)) }

--- a/src/Modifiers.re
+++ b/src/Modifiers.re
@@ -20,4 +20,4 @@ let equals = (mod1, mod2) => {
   && mod1.altGr == mod2.altGr
   && mod1.shift == mod2.shift
   && mod1.meta == mod2.meta;
-}
+};

--- a/src/Modifiers.re
+++ b/src/Modifiers.re
@@ -23,4 +23,10 @@ let none = {
   meta: false,
 };
 
-let equals = (_, _) => true;
+let equals = (mod1, mod2) => {
+  mod1.control == mod2.control
+  && mod1.alt == mod2.alt
+  && mod1.altGr == mod2.altGr
+  && mod1.shift == mod2.shift
+  && mod1.meta == mod2.meta;
+}

--- a/src/Modifiers.re
+++ b/src/Modifiers.re
@@ -1,12 +1,26 @@
 type t = {
   control: bool,
   alt: bool,
+  altGr: bool,
   shift: bool,
   meta: bool,
 };
 
-let create = (~control, ~alt, ~shift, ~meta) => {control, alt, shift, meta};
+let create =
+    (~control=false, ~alt=false, ~altGr=false, ~shift=false, ~meta=false, ()) => {
+  control,
+  alt,
+  altGr,
+  shift,
+  meta,
+};
 
-let none = {control: false, alt: false, shift: false, meta: false};
+let none = {
+  control: false,
+  alt: false,
+  altGr: false,
+  shift: false,
+  meta: false,
+};
 
 let equals = (_, _) => true;

--- a/test/InputTest.re
+++ b/test/InputTest.re
@@ -51,7 +51,7 @@ describe("EditorInput", ({describe, _}) => {
            );
 
       let (bindings, effects) =
-        Input.keyDown(~context=true, aKeyNoModifiers, bindings);
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
 
       expect.equal(effects, []);
 
@@ -73,15 +73,19 @@ describe("EditorInput", ({describe, _}) => {
              "payload1",
            );
 
-      let (bindings, effects) =
-        Input.keyDown(~context=true, aKeyNoModifiers, bindings);
+      expect.equal(Input.isPending(bindings), false);
 
+      let (bindings, effects) =
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
+
+      expect.equal(Input.isPending(bindings), true);
       expect.equal(effects, []);
 
       let (bindings, effects) =
-        Input.keyDown(~context=true, bKeyNoModifiers, bindings);
+        Input.keyDown(~context=true, ~key=bKeyNoModifiers, bindings);
 
       expect.equal(effects, [Execute("payload1")]);
+      expect.equal(Input.isPending(bindings), false);
     });
     test("same key in a sequence", ({expect}) => {
       let (bindings, _id) =
@@ -96,12 +100,12 @@ describe("EditorInput", ({describe, _}) => {
            );
 
       let (bindings, effects) =
-        Input.keyDown(~context=true, aKeyNoModifiers, bindings);
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
 
       expect.equal(effects, []);
 
       let (bindings, effects) =
-        Input.keyDown(~context=true, aKeyNoModifiers, bindings);
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
 
       expect.equal(effects, [Execute("payloadAA")]);
     });
@@ -118,17 +122,17 @@ describe("EditorInput", ({describe, _}) => {
            );
 
       let (bindings, effects) =
-        Input.keyDown(~context=true, aKeyNoModifiers, bindings);
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
 
       expect.equal(effects, []);
 
       let (bindings, effects) =
-        Input.keyUp(~context=true, aKeyNoModifiers, bindings);
+        Input.keyUp(~context=true, ~key=aKeyNoModifiers, bindings);
 
       expect.equal(effects, []);
 
       let (bindings, effects) =
-        Input.keyDown(~context=true, bKeyNoModifiers, bindings);
+        Input.keyDown(~context=true, ~key=bKeyNoModifiers, bindings);
 
       expect.equal(effects, [Execute("payloadAB")]);
     });
@@ -145,12 +149,12 @@ describe("EditorInput", ({describe, _}) => {
            );
 
       let (bindings, effects) =
-        Input.keyDown(~context=true, aKeyNoModifiers, bindings);
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
 
       expect.equal(effects, []);
 
       let (bindings, effects) =
-        Input.keyUp(~context=true, aKeyNoModifiers, bindings);
+        Input.keyUp(~context=true, ~key=aKeyNoModifiers, bindings);
 
       expect.equal(effects, [Execute("payloadA!A")]);
     });
@@ -175,17 +179,17 @@ describe("EditorInput", ({describe, _}) => {
            );
 
       let (bindings, effects) =
-        Input.keyDown(~context=true, aKeyNoModifiers, bindings);
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
 
       expect.equal(effects, []);
 
       let (bindings, effects) =
-        Input.keyDown(~context=true, aKeyNoModifiers, bindings);
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
 
       expect.equal(effects, [Execute("payloadA")]);
 
       let (_bindings, effects) =
-        Input.keyDown(~context=true, cKeyNoModifiers, bindings);
+        Input.keyDown(~context=true, ~key=cKeyNoModifiers, bindings);
 
       expect.equal(effects, [Execute("payloadAC")]);
     });
@@ -210,12 +214,12 @@ describe("EditorInput", ({describe, _}) => {
            );
 
       let (bindings, effects) =
-        Input.keyDown(~context=true, aKeyNoModifiers, bindings);
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
 
       expect.equal(effects, []);
 
       let (bindings, effects) =
-        Input.keyDown(~context=true, bKeyNoModifiers, bindings);
+        Input.keyDown(~context=true, ~key=bKeyNoModifiers, bindings);
 
       expect.equal(
         effects,
@@ -235,7 +239,7 @@ describe("EditorInput", ({describe, _}) => {
            );
 
       let (_bindings, effects) =
-        Input.keyDown(~context=false, aKeyNoModifiers, bindings);
+        Input.keyDown(~context=false, ~key=aKeyNoModifiers, bindings);
 
       // Should be unhandled because the context function is [false]
       expect.equal(effects, [Unhandled(aKeyNoModifiers)]);
@@ -253,7 +257,7 @@ describe("EditorInput", ({describe, _}) => {
            );
 
       let (bindings, effects) =
-        Input.keyDown(~context=false, aKeyNoModifiers, bindings);
+        Input.keyDown(~context=false, ~key=aKeyNoModifiers, bindings);
 
       expect.equal(effects, [Unhandled(aKeyNoModifiers)]);
     });
@@ -269,7 +273,7 @@ describe("EditorInput", ({describe, _}) => {
            );
 
       let (_bindings, effects) =
-        Input.keyDown(~context=true, aKeyNoModifiers, bindings);
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
 
       expect.equal(effects, [Execute("payload1")]);
     });
@@ -277,7 +281,7 @@ describe("EditorInput", ({describe, _}) => {
       let bindings = Input.empty;
 
       let (_bindings, effects) =
-        Input.keyDown(~context=true, aKeyNoModifiers, bindings);
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
 
       expect.equal(effects, [Unhandled(aKeyNoModifiers)]);
     });
@@ -293,7 +297,7 @@ describe("EditorInput", ({describe, _}) => {
            );
 
       let (_bindings, effects) =
-        Input.keyDown(~context=true, aKeyNoModifiers, bindings);
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
 
       expect.equal(effects, [Unhandled(bKeyNoModifiers)]);
     });
@@ -311,10 +315,10 @@ describe("EditorInput", ({describe, _}) => {
            );
 
       let (bindings, effects) =
-        Input.keyDown(~context=true, aKeyNoModifiers, bindings);
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
       expect.equal(effects, []);
       let (_bindings, effects) =
-        Input.keyDown(~context=true, bKeyNoModifiers, bindings);
+        Input.keyDown(~context=true, ~key=bKeyNoModifiers, bindings);
 
       expect.equal(effects, [Unhandled(cKeyNoModifiers)]);
     });
@@ -350,7 +354,7 @@ describe("EditorInput", ({describe, _}) => {
            );
 
       let (_bindings, effects) =
-        Input.keyDown(~context=true, aKeyNoModifiers, bindings);
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
 
       expect.equal(effects, [Execute("payload2")]);
     });

--- a/test/InputTest.re
+++ b/test/InputTest.re
@@ -62,15 +62,13 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [
-               Keydown(Keycode(1, Modifiers.none)),
-             ],
+             [Keydown(Keycode(1, Modifiers.none))],
              _ => true,
              "payloadA",
            );
 
-        let (_bindings, effects) = Input.text(~text="a", bindings);
-        expect.equal(effects, [Text("a")]);
+      let (_bindings, effects) = Input.text(~text="a", bindings);
+      expect.equal(effects, [Text("a")]);
     });
     test("should be held in sequence", ({expect}) => {
       let (bindings, _id) =
@@ -87,17 +85,17 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _effects) =
         Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
 
-      let (bindings, _effects) =
-        Input.text(~text="a", bindings);
+      let (bindings, _effects) = Input.text(~text="a", bindings);
 
       // Sequence fails - get text event
       let (_bindings, effects) =
         Input.keyDown(~context=true, ~key=cKeyNoModifiers, bindings);
 
       expect.equal(effects, [Text("a"), Unhandled(cKeyNoModifiers)]);
-    })
+    });
 
-    test("text after successful binding should not be dispatched", ({expect}) => {
+    test(
+      "text after successful binding should not be dispatched", ({expect}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
@@ -112,8 +110,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _effects) =
         Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
 
-      let (bindings, _effects) =
-        Input.text(~text="a", bindings);
+      let (bindings, _effects) = Input.text(~text="a", bindings);
 
       // Sequence fails - get text event
       let (bindings, effects) =
@@ -121,12 +118,11 @@ describe("EditorInput", ({describe, _}) => {
 
       expect.equal(effects, [Execute("payloadAB")]);
 
-      let (_bindings, effects) =
-        Input.text(~text="b", bindings);
-      
+      let (_bindings, effects) = Input.text(~text="b", bindings);
+
       // Subsequent text input should be ignored
       expect.equal(effects, []);
-    })
+    });
 
     test("text not dispatched in sequence", ({expect}) => {
       let (bindings, _id) =
@@ -143,15 +139,14 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _effects) =
         Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
 
-      let (bindings, _effects) =
-        Input.text(~text="a", bindings);
+      let (bindings, _effects) = Input.text(~text="a", bindings);
 
       // Sequence fails - get text event
       let (_bindings, effects) =
         Input.keyDown(~context=true, ~key=bKeyNoModifiers, bindings);
 
       expect.equal(effects, [Execute("payloadAB")]);
-    })
+    });
   });
   describe("sequences", ({test, _}) => {
     test("simple sequence", ({expect}) => {

--- a/test/InputTest.re
+++ b/test/InputTest.re
@@ -5,21 +5,18 @@ let aKeyNoModifiers: key = {
   scancode: 101,
   keycode: 1,
   modifiers: Modifiers.none,
-  text: "a",
 };
 
 let bKeyNoModifiers: key = {
   scancode: 102,
   keycode: 2,
   modifiers: Modifiers.none,
-  text: "b",
 };
 
 let cKeyNoModifiers: key = {
   scancode: 103,
   keycode: 3,
   modifiers: Modifiers.none,
-  text: "c",
 };
 
 module Input =
@@ -58,6 +55,102 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, effects) = Input.flush(~context=true, bindings);
 
       expect.equal(effects, [Execute("payloadA")]);
+    })
+  });
+  describe("text", ({test, _}) => {
+    test("should immediately dispatch if no pending keys", ({expect}) => {
+      let (bindings, _id) =
+        Input.empty
+        |> Input.addBinding(
+             [
+               Keydown(Keycode(1, Modifiers.none)),
+             ],
+             _ => true,
+             "payloadA",
+           );
+
+        let (_bindings, effects) = Input.text(~text="a", bindings);
+        expect.equal(effects, [Text("a")]);
+    });
+    test("should be held in sequence", ({expect}) => {
+      let (bindings, _id) =
+        Input.empty
+        |> Input.addBinding(
+             [
+               Keydown(Keycode(1, Modifiers.none)),
+               Keydown(Keycode(2, Modifiers.none)),
+             ],
+             _ => true,
+             "payloadAB",
+           );
+
+      let (bindings, _effects) =
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
+
+      let (bindings, _effects) =
+        Input.text(~text="a", bindings);
+
+      // Sequence fails - get text event
+      let (_bindings, effects) =
+        Input.keyDown(~context=true, ~key=cKeyNoModifiers, bindings);
+
+      expect.equal(effects, [Text("a"), Unhandled(cKeyNoModifiers)]);
+    })
+
+    test("text after successful binding should not be dispatched", ({expect}) => {
+      let (bindings, _id) =
+        Input.empty
+        |> Input.addBinding(
+             [
+               Keydown(Keycode(1, Modifiers.none)),
+               Keydown(Keycode(2, Modifiers.none)),
+             ],
+             _ => true,
+             "payloadAB",
+           );
+
+      let (bindings, _effects) =
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
+
+      let (bindings, _effects) =
+        Input.text(~text="a", bindings);
+
+      // Sequence fails - get text event
+      let (bindings, effects) =
+        Input.keyDown(~context=true, ~key=bKeyNoModifiers, bindings);
+
+      expect.equal(effects, [Execute("payloadAB")]);
+
+      let (_bindings, effects) =
+        Input.text(~text="b", bindings);
+      
+      // Subsequent text input should be ignored
+      expect.equal(effects, []);
+    })
+
+    test("text not dispatched in sequence", ({expect}) => {
+      let (bindings, _id) =
+        Input.empty
+        |> Input.addBinding(
+             [
+               Keydown(Keycode(1, Modifiers.none)),
+               Keydown(Keycode(2, Modifiers.none)),
+             ],
+             _ => true,
+             "payloadAB",
+           );
+
+      let (bindings, _effects) =
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
+
+      let (bindings, _effects) =
+        Input.text(~text="a", bindings);
+
+      // Sequence fails - get text event
+      let (_bindings, effects) =
+        Input.keyDown(~context=true, ~key=bKeyNoModifiers, bindings);
+
+      expect.equal(effects, [Execute("payloadAB")]);
     })
   });
   describe("sequences", ({test, _}) => {

--- a/test/MatcherTest.re
+++ b/test/MatcherTest.re
@@ -5,6 +5,8 @@ let getKeycode =
   fun
   | "a" => Some(1)
   | "b" => Some(2)
+  | "Escape" => Some(99)
+  | "Up" => Some(100)
   | _ => None;
 
 let getScancode =
@@ -28,6 +30,9 @@ describe("Matcher", ({describe, _}) => {
 
       let result = defaultParse("c");
       expect.equal(Result.is_error(result), true);
+
+      let result = defaultParse("esc");
+      expect.equal(result, Ok([Keydown(Keycode(99, Modifiers.none))]));
     });
     test("vim bindings", ({expect}) => {
       let result = defaultParse("<a>");


### PR DESCRIPTION
The 'text' tracking is somewhat complicated - when there is a `keyDown`, a `text` event can also be produced (via the SDL2 API). This adds tracking for the `text` event - by associating the `text` with the last `keyDown`, and flushing the `text` whenever the associated `keyDown` is unhandled.

This is important for a case like binding `jk` to a command, and then, if there is this sequence of actions:
- `keyDown` - `j`
- `text` - `j`
- `keyUp` - `j`
- `keyDown` - `a`
- `text` - `a`
- `keyUp` - `a`

At the point of `keyDown` - `a`, we know that the binding won't be executed, and we should flush the `j` text event, so that the interfacing program can handle it.

Another case that was challenging, in the same bind-`jk`-to-command scenario, was if the sequence is completed correctly:
- `keyDown` - `j`
- `text` - `j`
- `keyUp` - `j`
- `keyDown` - `k`
- `text` - `k`
- `keyUp` - `k`

The binding for `jk` gets executed on _keydown_ - but we actually don't want to send out a `text` event for `k` - since it was part of the binding that participating in executing the command. So we need to prevent that until we see an associated `keyUp`.
