### PR TITLE
API: <release> (all keys released) binding

### DIFF
--- a/src/EditorInput.re
+++ b/src/EditorInput.re
@@ -131,9 +131,7 @@ module Make = (Config: {
           key.scancode == scancode && Modifiers.equals(mods, key.modifiers)
         | (Keyup(Keycode(keycode, mods)), Up(key)) =>
           key.keycode == keycode && Modifiers.equals(mods, key.modifiers)
-        | (AllKeysReleased, AllKeysReleased) =>
-          prerr_endline("All keys released case");
-          true;
+        | (AllKeysReleased, AllKeysReleased) => true
         | _ => false
         };
       }
@@ -490,14 +488,6 @@ module Make = (Config: {
             }
           | [] => []
           };
-
-        effect
-        |> List.iter(
-             fun
-             | Execute(_) => prerr_endline("EXECUTE")
-             | Unhandled(_) => prerr_endline("UNHANDLED")
-             | Text(txt) => prerr_endline("TEXT: " ++ txt),
-           );
 
         effect;
       } else {

--- a/src/EditorInput.rei
+++ b/src/EditorInput.rei
@@ -51,7 +51,8 @@ module Matcher: {
 
   type t =
     | Keydown(keyMatcher)
-    | Keyup(keyMatcher);
+    | Keyup(keyMatcher)
+    | AllKeysReleased;
 
   type sequence = list(t);
 

--- a/src/Matcher.re
+++ b/src/Matcher.re
@@ -49,7 +49,7 @@ let parse = (~getKeycode, ~getScancode, str) => {
           | Matcher_internal.Keyup =>
             Ok(Keyup(Keycode(code, internalModsToMods(mods))))
           }
-        };
+        }
       | Matcher_internal.AllKeysReleased => Ok(AllKeysReleased)
       };
     };

--- a/src/Matcher.re
+++ b/src/Matcher.re
@@ -4,7 +4,8 @@ type keyMatcher =
 
 type t =
   | Keydown(keyMatcher)
-  | Keyup(keyMatcher);
+  | Keyup(keyMatcher)
+  | AllKeysReleased;
 
 type sequence = list(t);
 
@@ -37,16 +38,19 @@ let parse = (~getKeycode, ~getScancode, str) => {
 
   let finish = r => {
     let f = parseResult => {
-      let (activation, key, mods) = parseResult;
-      switch (getKeycode(key)) {
-      | None => Error("Unrecognized key: " ++ Key.toString(key))
-      | Some(code) =>
-        switch (activation) {
-        | Matcher_internal.Keydown =>
-          Ok(Keydown(Keycode(code, internalModsToMods(mods))))
-        | Matcher_internal.Keyup =>
-          Ok(Keyup(Keycode(code, internalModsToMods(mods))))
-        }
+      switch (parseResult) {
+      | Matcher_internal.Key((activation, key, mods)) =>
+        switch (getKeycode(key)) {
+        | None => Error("Unrecognized key: " ++ Key.toString(key))
+        | Some(code) =>
+          switch (activation) {
+          | Matcher_internal.Keydown =>
+            Ok(Keydown(Keycode(code, internalModsToMods(mods))))
+          | Matcher_internal.Keyup =>
+            Ok(Keyup(Keycode(code, internalModsToMods(mods))))
+          }
+        };
+      | Matcher_internal.AllKeysReleased => Ok(AllKeysReleased)
       };
     };
 

--- a/src/Matcher_internal.re
+++ b/src/Matcher_internal.re
@@ -6,6 +6,8 @@ type modifier =
 
 type activation =
   | Keyup
-  | Keydown;
+  | Keydown
 
-type t = (activation, Key.t, list(modifier));
+type t =
+| Key((activation, Key.t, list(modifier)))
+| AllKeysReleased;

--- a/src/Matcher_internal.re
+++ b/src/Matcher_internal.re
@@ -6,8 +6,8 @@ type modifier =
 
 type activation =
   | Keyup
-  | Keydown
+  | Keydown;
 
 type t =
-| Key((activation, Key.t, list(modifier)))
-| AllKeysReleased;
+  | Key((activation, Key.t, list(modifier)))
+  | AllKeysReleased;

--- a/src/Matcher_lexer.mll
+++ b/src/Matcher_lexer.mll
@@ -39,6 +39,7 @@ rule token = parse
 	with Not_found ->
 		raise (UnrecognizedModifier m)
  }
+| "<release>" { ALLKEYSRELEASED }
 | 'f' (['0'-'9'] as m) { BINDING ( Function(int_of_string (String.make 1 m)) ) }
 | 'f' '1' (['0'-'9'] as m) { BINDING ( Function(int_of_string ("1" ^ (String.make 1 m))) ) }
 | 'f' '1' (['0'-'9'] as m) { BINDING ( Function(int_of_string ("1" ^ (String.make 1 m))) ) }

--- a/src/Matcher_parser.mly
+++ b/src/Matcher_parser.mly
@@ -1,5 +1,6 @@
 %token <Matcher_internal.modifier> MODIFIER
 %token <Key.t> BINDING
+%token ALLKEYSRELEASED
 %token LT GT
 %token EXCLAMATION
 %token EOF
@@ -12,14 +13,15 @@ main:
 | phrase = list(expr) EOF { phrase }
 
 expr:
+| ALLKEYSRELEASED { Matcher_internal.AllKeysReleased }
 | EXCLAMATION; LT e = keyup_binding GT { e }
 | EXCLAMATION; s = keyup_binding { s }
 | LT e = keydown_binding GT { e }
 | s = keydown_binding { s }
 
 keyup_binding:
-| modifiers = list(MODIFIER); binding = BINDING { (Matcher_internal.Keyup, binding, modifiers) }
+| modifiers = list(MODIFIER); binding = BINDING { Matcher_internal.Key((Matcher_internal.Keyup, binding, modifiers)) }
 
 keydown_binding:
-| modifiers = list(MODIFIER); binding = BINDING { (Matcher_internal.Keydown, binding, modifiers) }
+| modifiers = list(MODIFIER); binding = BINDING { Matcher_internal.Key((Matcher_internal.Keydown, binding, modifiers)) }
 

--- a/test/InputTest.re
+++ b/test/InputTest.re
@@ -57,6 +57,29 @@ describe("EditorInput", ({describe, _}) => {
       expect.equal(effects, [Execute("payloadA")]);
     })
   });
+  describe("allKeysReleased", ({test, _}) => {
+
+    test("basic release case", ({expect}) => {
+      let (bindings, _id) =
+        Input.empty
+        |> Input.addBinding(
+             [AllKeysReleased],
+             _ => true,
+             "payloadA",
+           );
+
+      let (bindings, effects) =
+        Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
+      expect.equal(effects, [Unhandled(aKeyNoModifiers)]);
+
+      let (bindings, effects) =
+        Input.keyUp(~context=true, ~key=aKeyNoModifiers, bindings);
+      
+      expect.equal(effects, [Execute("payloadA")]);
+      
+    })
+
+  });
   describe("text", ({test, _}) => {
     test("should immediately dispatch if no pending keys", ({expect}) => {
       let (bindings, _id) =

--- a/test/InputTest.re
+++ b/test/InputTest.re
@@ -58,15 +58,10 @@ describe("EditorInput", ({describe, _}) => {
     })
   });
   describe("allKeysReleased", ({test, _}) => {
-
     test("basic release case", ({expect}) => {
       let (bindings, _id) =
         Input.empty
-        |> Input.addBinding(
-             [AllKeysReleased],
-             _ => true,
-             "payloadA",
-           );
+        |> Input.addBinding([AllKeysReleased], _ => true, "payloadA");
 
       let (bindings, effects) =
         Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
@@ -74,11 +69,9 @@ describe("EditorInput", ({describe, _}) => {
 
       let (bindings, effects) =
         Input.keyUp(~context=true, ~key=aKeyNoModifiers, bindings);
-      
-      expect.equal(effects, [Execute("payloadA")]);
-      
-    })
 
+      expect.equal(effects, [Execute("payloadA")]);
+    })
   });
   describe("text", ({test, _}) => {
     test("should immediately dispatch if no pending keys", ({expect}) => {

--- a/test/MatcherTest.re
+++ b/test/MatcherTest.re
@@ -135,6 +135,10 @@ describe("Matcher", ({describe, _}) => {
       let result = defaultParse("esc");
       expect.equal(result, Ok([Keydown(Keycode(99, Modifiers.none))]));
     });
+    test("all keys released", ({expect}) => {
+      let result = defaultParse("<RELEASE>");
+      expect.equal(result, Ok([AllKeysReleased]));
+    });
     test("vim bindings", ({expect}) => {
       let result = defaultParse("<a>");
       expect.equal(result, Ok([Keydown(Keycode(1, Modifiers.none))]));


### PR DESCRIPTION
This PR adds a special `<release>` key binding - this is triggered when all keys are released, and cannot be combined with other matchers or bindings.

This is used to handle a special-case we had in Onivim 2 for the `Control+Tab` editor selector - when the keys are released, we wanted to engage a `list.select` action. This generalizes it, so that we can use this in other places, too.

It probably doesn't make sense to bind `<release>` without a condition - in the Onivim 2 case, we use a binding like:
```
{ key: "<release>", command: "list.select", condition: "inEditorsPicker" }
```