### PR TITLE
API: Add count method

### DIFF
--- a/src/EditorInput.re
+++ b/src/EditorInput.re
@@ -39,6 +39,8 @@ module type Input = {
 
   let isPending: t => bool;
 
+  let count: t => int;
+
   let concat: (t, t) => t;
 
   let empty: t;
@@ -109,6 +111,8 @@ module Make = (Config: {
     keys: list(gesture),
     pressedScancodes: IntSet.t,
   };
+
+  let count = ({bindings, _}) => List.length(bindings);
 
   let concat = (first, second) => {
     suppressText: false,

--- a/src/EditorInput.rei
+++ b/src/EditorInput.rei
@@ -101,6 +101,8 @@ module type Input = {
   */
   let isPending: t => bool;
 
+  let count: t => int;
+
   let concat: (t, t) => t;
 
   let empty: t;


### PR DESCRIPTION
Add a `count` method for bindings - needed for some validation in the Onivim 2 unit tests.