### PR TITLE
Refactor - API: AllKeysReleased to top-level matcher

### DIFF
--- a/src/EditorInput.re
+++ b/src/EditorInput.re
@@ -154,10 +154,16 @@ module Make = (Config: {
       | Unmatched(Matcher.Sequence([hd, ...tail])) when keyMatches(hd, key) =>
         if (tail == []) {
           // If the sequence is fully exercise, we're matched!
-          Some({...binding, matcher: Matched});
+          Some({
+            ...binding,
+            matcher: Matched,
+          });
         } else {
           // Otherwise, pull the matched key off, and leave the remainder of keys to match
-          Some({...binding, matcher: Unmatched(Matcher.Sequence(tail))});
+          Some({
+            ...binding,
+            matcher: Unmatched(Matcher.Sequence(tail)),
+          });
         }
       | _ => None
       };

--- a/src/EditorInput.rei
+++ b/src/EditorInput.rei
@@ -49,12 +49,13 @@ module Matcher: {
     | Scancode(int, Modifiers.t)
     | Keycode(int, Modifiers.t);
 
-  type t =
+  type keyPress =
     | Keydown(keyMatcher)
-    | Keyup(keyMatcher)
-    | AllKeysReleased;
+    | Keyup(keyMatcher);
 
-  type sequence = list(t);
+  type t =
+    | Sequence(list(keyPress))
+    | AllKeysReleased;
 
   let parse:
     (
@@ -62,7 +63,7 @@ module Matcher: {
       ~getScancode: Key.t => option(int),
       string
     ) =>
-    result(sequence, string);
+    result(t, string);
 };
 
 type keyPress = {
@@ -79,11 +80,10 @@ module type Input = {
 
   type uniqueId;
 
-  let addBinding:
-    (Matcher.sequence, context => bool, payload, t) => (t, uniqueId);
+  let addBinding: (Matcher.t, context => bool, payload, t) => (t, uniqueId);
 
   let addMapping:
-    (Matcher.sequence, context => bool, list(keyPress), t) => (t, uniqueId);
+    (Matcher.t, context => bool, list(keyPress), t) => (t, uniqueId);
 
   type effects =
     | Execute(payload)

--- a/src/Matcher.re
+++ b/src/Matcher.re
@@ -53,8 +53,6 @@ let parse = (~getKeycode, ~getScancode, str) => {
       };
     };
 
-    //let bindings = r |> List.map(f);
-
     switch (r) {
     | Matcher_internal.AllKeysReleased => Ok(AllKeysReleased)
     | Matcher_internal.Sequence(keys) =>

--- a/src/Matcher.re
+++ b/src/Matcher.re
@@ -2,9 +2,12 @@ type keyMatcher =
   | Scancode(int, Modifiers.t)
   | Keycode(int, Modifiers.t);
 
-type t =
+type keyPress =
   | Keydown(keyMatcher)
-  | Keyup(keyMatcher)
+  | Keyup(keyMatcher);
+
+type t =
+  | Sequence(list(keyPress))
   | AllKeysReleased;
 
 type sequence = list(t);
@@ -37,43 +40,45 @@ let parse = (~getKeycode, ~getScancode, str) => {
   };
 
   let finish = r => {
-    let f = parseResult => {
-      switch (parseResult) {
-      | Matcher_internal.Key((activation, key, mods)) =>
-        switch (getKeycode(key)) {
-        | None => Error("Unrecognized key: " ++ Key.toString(key))
-        | Some(code) =>
-          switch (activation) {
-          | Matcher_internal.Keydown =>
-            Ok(Keydown(Keycode(code, internalModsToMods(mods))))
-          | Matcher_internal.Keyup =>
-            Ok(Keyup(Keycode(code, internalModsToMods(mods))))
-          }
+    let f = ((activation, key, mods)) => {
+      switch (getKeycode(key)) {
+      | None => Error("Unrecognized key: " ++ Key.toString(key))
+      | Some(code) =>
+        switch (activation) {
+        | Matcher_internal.Keydown =>
+          Ok(Keydown(Keycode(code, internalModsToMods(mods))))
+        | Matcher_internal.Keyup =>
+          Ok(Keyup(Keycode(code, internalModsToMods(mods))))
         }
-      | Matcher_internal.AllKeysReleased => Ok(AllKeysReleased)
       };
     };
 
-    let bindings = r |> List.map(f);
+    //let bindings = r |> List.map(f);
 
-    let errors = bindings |> List.filter(Result.is_error);
+    switch (r) {
+    | Matcher_internal.AllKeysReleased => Ok(AllKeysReleased)
+    | Matcher_internal.Sequence(keys) =>
+      let bindings = keys |> List.map(f);
 
-    if (List.length(errors) > 0) {
-      let stringErrors =
-        errors
-        |> List.filter_map(
-             fun
-             | Error(msg) => Some(msg)
-             | Ok(_) => None,
-           );
+      let errors = bindings |> List.filter(Result.is_error);
 
-      let firstError: string = List.nth(stringErrors, 0);
-      Error(firstError);
-    } else {
-      bindings
-      |> List.map(Result.to_option)
-      |> List.filter_map(v => v)
-      |> (out => Ok(out));
+      if (List.length(errors) > 0) {
+        let stringErrors =
+          errors
+          |> List.filter_map(
+               fun
+               | Error(msg) => Some(msg)
+               | Ok(_) => None,
+             );
+
+        let firstError: string = List.nth(stringErrors, 0);
+        Error(firstError);
+      } else {
+        bindings
+        |> List.map(Result.to_option)
+        |> List.filter_map(v => v)
+        |> (out => Ok(Sequence(out)));
+      };
     };
   };
 

--- a/src/Matcher_internal.re
+++ b/src/Matcher_internal.re
@@ -8,6 +8,8 @@ type activation =
   | Keyup
   | Keydown;
 
+type keyMatcher = (activation, Key.t, list(modifier));
+
 type t =
-  | Key((activation, Key.t, list(modifier)))
+  | Sequence(list(keyMatcher))
   | AllKeysReleased;

--- a/src/Matcher_parser.mly
+++ b/src/Matcher_parser.mly
@@ -5,23 +5,23 @@
 %token EXCLAMATION
 %token EOF
 
-%start <Matcher_internal.t list> main
+%start <Matcher_internal.t> main
 
 %%
 
 main:
-| phrase = list(expr) EOF { phrase }
+| ALLKEYSRELEASED { Matcher_internal.AllKeysReleased }
+| phrase = list(expr) EOF { Matcher_internal.Sequence(phrase) }
 
 expr:
-| ALLKEYSRELEASED { Matcher_internal.AllKeysReleased }
 | EXCLAMATION; LT e = keyup_binding GT { e }
 | EXCLAMATION; s = keyup_binding { s }
 | LT e = keydown_binding GT { e }
 | s = keydown_binding { s }
 
 keyup_binding:
-| modifiers = list(MODIFIER); binding = BINDING { Matcher_internal.Key((Matcher_internal.Keyup, binding, modifiers)) }
+| modifiers = list(MODIFIER); binding = BINDING { (Matcher_internal.Keyup, binding, modifiers) }
 
 keydown_binding:
-| modifiers = list(MODIFIER); binding = BINDING { Matcher_internal.Key((Matcher_internal.Keydown, binding, modifiers)) }
+| modifiers = list(MODIFIER); binding = BINDING { (Matcher_internal.Keydown, binding, modifiers) }
 

--- a/test/InputTest.re
+++ b/test/InputTest.re
@@ -31,10 +31,10 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [
+             Sequence([
                Keydown(Keycode(1, Modifiers.none)),
                Keydown(Keycode(2, Modifiers.none)),
-             ],
+             ]),
              _ => true,
              "payloadAB",
            );
@@ -42,7 +42,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         bindings
         |> Input.addBinding(
-             [Keydown(Keycode(1, Modifiers.none))],
+             Sequence([Keydown(Keycode(1, Modifiers.none))]),
              _ => true,
              "payloadA",
            );
@@ -61,7 +61,7 @@ describe("EditorInput", ({describe, _}) => {
     test("basic release case", ({expect}) => {
       let (bindings, _id) =
         Input.empty
-        |> Input.addBinding([AllKeysReleased], _ => true, "payloadA");
+        |> Input.addBinding(AllKeysReleased, _ => true, "payloadA");
 
       let (bindings, effects) =
         Input.keyDown(~context=true, ~key=aKeyNoModifiers, bindings);
@@ -78,7 +78,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [Keydown(Keycode(1, Modifiers.none))],
+             Sequence([Keydown(Keycode(1, Modifiers.none))]),
              _ => true,
              "payloadA",
            );
@@ -90,10 +90,10 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [
+             Sequence([
                Keydown(Keycode(1, Modifiers.none)),
                Keydown(Keycode(2, Modifiers.none)),
-             ],
+             ]),
              _ => true,
              "payloadAB",
            );
@@ -115,10 +115,10 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [
+             Sequence([
                Keydown(Keycode(1, Modifiers.none)),
                Keydown(Keycode(2, Modifiers.none)),
-             ],
+             ]),
              _ => true,
              "payloadAB",
            );
@@ -144,10 +144,10 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [
+             Sequence([
                Keydown(Keycode(1, Modifiers.none)),
                Keydown(Keycode(2, Modifiers.none)),
-             ],
+             ]),
              _ => true,
              "payloadAB",
            );
@@ -169,10 +169,10 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [
+             Sequence([
                Keydown(Keycode(1, Modifiers.none)),
                Keydown(Keycode(2, Modifiers.none)),
-             ],
+             ]),
              _ => true,
              "payload1",
            );
@@ -195,10 +195,10 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [
+             Sequence([
                Keydown(Keycode(1, Modifiers.none)),
                Keydown(Keycode(1, Modifiers.none)),
-             ],
+             ]),
              _ => true,
              "payloadAA",
            );
@@ -217,10 +217,10 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [
+             Sequence([
                Keydown(Keycode(1, Modifiers.none)),
                Keydown(Keycode(2, Modifiers.none)),
-             ],
+             ]),
              _ => true,
              "payloadAB",
            );
@@ -244,10 +244,10 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [
+             Sequence([
                Keydown(Keycode(1, Modifiers.none)),
                Keyup(Keycode(1, Modifiers.none)),
-             ],
+             ]),
              _ => true,
              "payloadA!A",
            );
@@ -266,10 +266,10 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [
+             Sequence([
                Keydown(Keycode(1, Modifiers.none)),
                Keydown(Keycode(3, Modifiers.none)),
-             ],
+             ]),
              _ => true,
              "payloadAC",
            );
@@ -277,7 +277,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         bindings
         |> Input.addBinding(
-             [Keydown(Keycode(1, Modifiers.none))],
+             Sequence([Keydown(Keycode(1, Modifiers.none))]),
              _ => true,
              "payloadA",
            );
@@ -301,10 +301,10 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [
+             Sequence([
                Keydown(Keycode(1, Modifiers.none)),
                Keydown(Keycode(3, Modifiers.none)),
-             ],
+             ]),
              _ => true,
              "payloadAC",
            );
@@ -312,7 +312,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         bindings
         |> Input.addBinding(
-             [Keydown(Keycode(1, Modifiers.none))],
+             Sequence([Keydown(Keycode(1, Modifiers.none))]),
              _ => true,
              "payloadA",
            );
@@ -337,7 +337,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [Keydown(Keycode(1, Modifiers.none))],
+             Sequence([Keydown(Keycode(1, Modifiers.none))]),
              identity,
              "payload1",
            );
@@ -352,10 +352,10 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [
+             Sequence([
                Keydown(Keycode(1, Modifiers.none)),
                Keydown(Keycode(3, Modifiers.none)),
-             ],
+             ]),
              identity,
              "payloadAC",
            );
@@ -371,7 +371,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addBinding(
-             [Keydown(Keycode(1, Modifiers.none))],
+             Sequence([Keydown(Keycode(1, Modifiers.none))]),
              _ => true,
              "payload1",
            );
@@ -395,7 +395,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addMapping(
-             [Keydown(Keycode(1, Modifiers.none))],
+             Sequence([Keydown(Keycode(1, Modifiers.none))]),
              _ => true,
              [bKeyNoModifiers],
            );
@@ -410,7 +410,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addMapping(
-             [Keydown(Keycode(1, Modifiers.none))],
+             Sequence([Keydown(Keycode(1, Modifiers.none))]),
              _ => true,
              [bKeyNoModifiers],
            );
@@ -418,7 +418,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         bindings
         |> Input.addMapping(
-             [Keydown(Keycode(2, Modifiers.none))],
+             Sequence([Keydown(Keycode(2, Modifiers.none))]),
              _ => true,
              [cKeyNoModifiers],
            );
@@ -433,7 +433,7 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addMapping(
-             [Keydown(Keycode(1, Modifiers.none))],
+             Sequence([Keydown(Keycode(1, Modifiers.none))]),
              _ => true,
              [aKeyNoModifiers],
            );
@@ -448,10 +448,10 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addMapping(
-             [
+             Sequence([
                Keydown(Keycode(1, Modifiers.none)),
                Keydown(Keycode(2, Modifiers.none)),
-             ],
+             ]),
              _ => true,
              [cKeyNoModifiers],
            );
@@ -483,14 +483,14 @@ describe("EditorInput", ({describe, _}) => {
       let (bindings, _id) =
         Input.empty
         |> Input.addMapping(
-             [Keydown(Keycode(1, Modifiers.none))],
+             Sequence([Keydown(Keycode(1, Modifiers.none))]),
              _ => true,
              [bKeyNoModifiers],
            );
       let (bindings, _id) =
         bindings
         |> Input.addBinding(
-             [Keydown(Keycode(2, Modifiers.none))],
+             Sequence([Keydown(Keycode(2, Modifiers.none))]),
              _ => true,
              "payload2",
            );

--- a/test/MatcherTest.re
+++ b/test/MatcherTest.re
@@ -116,7 +116,7 @@ describe("Matcher", ({describe, _}) => {
         let (keyString, matcher) = case;
         let result = defaultParse(keyString);
 
-        expect.equal(result, Ok([matcher]));
+        expect.equal(result, Ok(Sequence([matcher])));
       };
 
       let _: unit = cases |> List.iter(runCase);
@@ -124,112 +124,155 @@ describe("Matcher", ({describe, _}) => {
     });
     test("simple parsing", ({expect}) => {
       let result = defaultParse("a");
-      expect.equal(result, Ok([Keydown(Keycode(1, Modifiers.none))]));
+      expect.equal(
+        result,
+        Ok(Sequence([Keydown(Keycode(1, Modifiers.none))])),
+      );
 
       let result = defaultParse("b");
-      expect.equal(result, Ok([Keydown(Keycode(2, Modifiers.none))]));
+      expect.equal(
+        result,
+        Ok(Sequence([Keydown(Keycode(2, Modifiers.none))])),
+      );
 
       let result = defaultParse("c");
       expect.equal(Result.is_error(result), true);
 
       let result = defaultParse("esc");
-      expect.equal(result, Ok([Keydown(Keycode(99, Modifiers.none))]));
+      expect.equal(
+        result,
+        Ok(Sequence([Keydown(Keycode(99, Modifiers.none))])),
+      );
     });
     test("all keys released", ({expect}) => {
       let result = defaultParse("<RELEASE>");
-      expect.equal(result, Ok([AllKeysReleased]));
+      expect.equal(result, Ok(AllKeysReleased));
     });
     test("vim bindings", ({expect}) => {
       let result = defaultParse("<a>");
-      expect.equal(result, Ok([Keydown(Keycode(1, Modifiers.none))]));
+      expect.equal(
+        result,
+        Ok(Sequence([Keydown(Keycode(1, Modifiers.none))])),
+      );
 
       let result = defaultParse("<c-a>");
-      expect.equal(result, Ok([Keydown(Keycode(1, modifiersControl))]));
+      expect.equal(
+        result,
+        Ok(Sequence([Keydown(Keycode(1, modifiersControl))])),
+      );
 
       let result = defaultParse("<S-a>");
-      expect.equal(result, Ok([Keydown(Keycode(1, modifiersShift))]));
+      expect.equal(
+        result,
+        Ok(Sequence([Keydown(Keycode(1, modifiersShift))])),
+      );
     });
     test("vscode bindings", ({expect}) => {
       let result = defaultParse("Ctrl+a");
-      expect.equal(result, Ok([Keydown(Keycode(1, modifiersControl))]));
+      expect.equal(
+        result,
+        Ok(Sequence([Keydown(Keycode(1, modifiersControl))])),
+      );
 
       let result = defaultParse("ctrl+a");
-      expect.equal(result, Ok([Keydown(Keycode(1, modifiersControl))]));
+      expect.equal(
+        result,
+        Ok(Sequence([Keydown(Keycode(1, modifiersControl))])),
+      );
     });
     test("binding list", ({expect}) => {
       let result = defaultParse("ab");
       expect.equal(
         result,
-        Ok([
-          Keydown(Keycode(1, Modifiers.none)),
-          Keydown(Keycode(2, Modifiers.none)),
-        ]),
+        Ok(
+          Sequence([
+            Keydown(Keycode(1, Modifiers.none)),
+            Keydown(Keycode(2, Modifiers.none)),
+          ]),
+        ),
       );
 
       let result = defaultParse("a b");
       expect.equal(
         result,
-        Ok([
-          Keydown(Keycode(1, Modifiers.none)),
-          Keydown(Keycode(2, Modifiers.none)),
-        ]),
+        Ok(
+          Sequence([
+            Keydown(Keycode(1, Modifiers.none)),
+            Keydown(Keycode(2, Modifiers.none)),
+          ]),
+        ),
       );
 
       let result = defaultParse("<a>b");
       expect.equal(
         result,
-        Ok([
-          Keydown(Keycode(1, Modifiers.none)),
-          Keydown(Keycode(2, Modifiers.none)),
-        ]),
+        Ok(
+          Sequence([
+            Keydown(Keycode(1, Modifiers.none)),
+            Keydown(Keycode(2, Modifiers.none)),
+          ]),
+        ),
       );
       let result = defaultParse("<a><b>");
       expect.equal(
         result,
-        Ok([
-          Keydown(Keycode(1, Modifiers.none)),
-          Keydown(Keycode(2, Modifiers.none)),
-        ]),
+        Ok(
+          Sequence([
+            Keydown(Keycode(1, Modifiers.none)),
+            Keydown(Keycode(2, Modifiers.none)),
+          ]),
+        ),
       );
 
       let result = defaultParse("<c-a> Ctrl+b");
       expect.equal(
         result,
-        Ok([
-          Keydown(Keycode(1, modifiersControl)),
-          Keydown(Keycode(2, modifiersControl)),
-        ]),
+        Ok(
+          Sequence([
+            Keydown(Keycode(1, modifiersControl)),
+            Keydown(Keycode(2, modifiersControl)),
+          ]),
+        ),
       );
     });
     test("keyup", ({expect}) => {
       let result = defaultParse("!a");
-      expect.equal(result, Ok([Keyup(Keycode(1, Modifiers.none))]));
+      expect.equal(
+        result,
+        Ok(Sequence([Keyup(Keycode(1, Modifiers.none))])),
+      );
 
       let result = defaultParse("a!a");
       expect.equal(
         result,
-        Ok([
-          Keydown(Keycode(1, Modifiers.none)),
-          Keyup(Keycode(1, Modifiers.none)),
-        ]),
+        Ok(
+          Sequence([
+            Keydown(Keycode(1, Modifiers.none)),
+            Keyup(Keycode(1, Modifiers.none)),
+          ]),
+        ),
       );
 
       let result = defaultParse("a !Ctrl+a");
       expect.equal(
         result,
-        Ok([
-          Keydown(Keycode(1, Modifiers.none)),
-          Keyup(Keycode(1, modifiersControl)),
-        ]),
+        Ok(
+          Sequence([
+            Keydown(Keycode(1, Modifiers.none)),
+            Keyup(Keycode(1, modifiersControl)),
+          ]),
+        ),
       );
 
       let result = defaultParse("a !<C-A>");
       expect.equal(
         result,
-        Ok([
-          Keydown(Keycode(1, Modifiers.none)),
-          Keyup(Keycode(1, modifiersControl)),
-        ]),
+        Ok(
+          Sequence([
+            Keydown(Keycode(1, Modifiers.none)),
+            Keyup(Keycode(1, modifiersControl)),
+          ]),
+        ),
       );
     });
   })


### PR DESCRIPTION
An awkard aspect of the current API, and parser, is that while `<release>` only makes sense individually - it was treated as a _list_ of matchers.

This changes the model, such that a key matcher can either be a `AllKeysReleased` binding _or_ a sequence (`list`) of keyPress bindings. 

Later, when we support 'chorded' keybindings (which, like `AllKeysReleased` would be exclusive - not used as part of a key sequence), we can use the top-level matcher and parser instead of including it in a list.